### PR TITLE
Merging from develop vcf-dedupper 0.4.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+version 0.4.3 (2 Aug 2017)
+----------------------------
+
+* Major changes
+    - Added parameter `--mem-percentage` to control the amount of available memory used by sort command. This is quite low otherwise, default value now set to 80%.
+
+* Minor changes
+    - Added parameter `--log-file` to write logs to a file. If not provided these are still written to the standard error.
+
 version 0.4.2 (12 Jul 2017)
 ----------------------------
 

--- a/scripts/vcf_dedupper
+++ b/scripts/vcf_dedupper
@@ -6,7 +6,7 @@ from vcf_dedup.runner import VcfDedupRunner
 
 def main():
 
-    parser = argparse.ArgumentParser(description = 'VCF variant duplication removal - vcf-dedup v0.4.2')
+    parser = argparse.ArgumentParser(description = 'VCF variant duplication removal - vcf-dedup v0.4.3')
     parser.add_argument('--input-vcf', metavar='input_vcf', help = 'The input VCF compressed or not [required]', required = True)
     parser.add_argument('--output-vcf', metavar='output_vcf', help='The output VCF. If not provided it will write to standard output', default=None)
     parser.add_argument('--variant-caller', metavar='variant_caller',
@@ -39,18 +39,20 @@ def main():
                         help='Sorts the VCF before dedupping. Beware that VCF needs to be sorted considering '
                              'chromosome, position, reference and alternate bases.',
                         action='store_true')
+    parser.add_argument('--sort-mem-percentage', metavar='sort_mem_percentage',
+                        help='The percentage of memory that sort will use. Values in the range [1, 100]. Default: 80',
+                        default="80")
+    parser.add_argument('--log-file', metavar='log_file',
+                        help='The file to which logs will be appended (default: stderr).',
+                        default="")
     parser.add_argument('--verbose', action='store_true')
     parser.set_defaults(equality_mode="1")
     parser.set_defaults(sample_idx=0)
     parser.set_defaults(sort_threads="1")
     parser.set_defaults(sort_tmp_folder="")
-
-
+    parser.set_defaults(sort_mem_percentage="80")
+    parser.set_defaults(log_file="")
     args = parser.parse_args()
-
-    # Sets logging level
-    logging.basicConfig(level = 10 if args.verbose else 40)
-    logging.debug("Arguments:" + str(args))
 
     # Creates a data structure with all config parameters
     config = {
@@ -64,8 +66,15 @@ def main():
         "sample_name": args.sample_name,
         "sort_vcf": args.sort,
         "sort_threads": args.sort_threads,
-        "temp_folder": args.sort_tmp_folder
+        "temp_folder": args.sort_tmp_folder,
+        "sort_mem_percentage": args.sort_mem_percentage,
+        "log_level" : 10 if args.verbose else 40
     }
+    if args.log_file != "":
+        config["log_file"] = args.log_file
+    if args.verbose:
+        config["verbose"] = True
+
     # Calls the VCF dedupper
     runner = VcfDedupRunner(config)
     runner.run()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='vcf-dedup',
-    version='0.4.2',
+    version='0.4.3',
     packages=find_packages(),
     scripts=['scripts/vcf_dedupper'],
     url='',

--- a/vcf_dedup/runner.py
+++ b/vcf_dedup/runner.py
@@ -13,8 +13,6 @@ class VcfDedupInputError(Exception):
 
 class VcfDedupRunner(object):
 
-    # TODO: add the rare diseases caller here, platypus?
-    # TODO: add others
     SUPPORTED_VARIANT_CALLERS = [
         STRELKA_VARIANT_CALLER,
         STARLING_VARIANT_CALLER,
@@ -33,8 +31,19 @@ class VcfDedupRunner(object):
         SELECTION_METHOD_QUALITY
     ]
 
+    SORT_MEM_PERCENTAGE_DEFAULT = 80
+    LOGGING_FORMAT = '%(asctime)s %(levelname)s %(message)s'
+
     def __init__(self, config):
         self.config = config
+
+        # Sets logging level
+        log_level = 20 if self.config.get('verbose') is True else 40
+        log_file = self.config.get('log_file')
+        if log_file != "" and log_file is not None:
+            logging.basicConfig(level=log_level, filename=log_file, format=self.LOGGING_FORMAT)
+        else:
+            logging.basicConfig(level=log_level, format=self.LOGGING_FORMAT)
         logging.debug("Configuration:")
         logging.debug(str(self.config))
         # checks that the configuration received is correct
@@ -45,35 +54,20 @@ class VcfDedupRunner(object):
         self.variant_caller = config["variant_caller"]
         self.selection_method = config["selection_method"]
         self.equality_mode = config["equality_mode"]
-        try:
-            self.sample_idx = int(config["sample_idx"]) if "sample_idx" in  config else None
-        except ValueError:
-            message = "'sample_idx' must be numeric"
-            logging.error(message)
-            raise VcfDedupInputError(message)
+        self.sample_idx = int(config["sample_idx"]) if "sample_idx" in config else None
         self.sample_name = config["sample_name"] if "sample_name" in config else None
-        try:
-            self.sort_vcf = bool(config["sort_vcf"])
-        except ValueError:
-            message = "'sort_vcf' must be boolean"
-            logging.error(message)
-            raise VcfDedupInputError(message)
-        try:
-            self.sort_threads = int(config["sort_threads"])
-            if self.sort_threads < 1:
-                message = "'sort_threads' must be positive and greater than zero [%s]" % str(self.sort_threads)
-                logging.error(message)
-                raise VcfDedupInputError(message)
-        except ValueError:
-            message = "'sort_threads' must be numeric"
-            logging.error(message)
-            raise VcfDedupInputError(message)
-        if "temp_folder" in config and config["temp_folder"] is not None:
+        self.sort_vcf = bool(config["sort_vcf"])
+        self.sort_threads = int(config["sort_threads"])
+        if config["temp_folder"] is not None:
             self.temp_folder = config["temp_folder"]
         else:
             self.temp_folder = os.path.dirname(os.path.realpath(
                 self.output_vcf if self.output_vcf is not None and self.output_vcf != "" else self.input_vcf
             ))
+        if config.get("sort_mem_percentage") is not None:
+            self.sort_mem_percentage = int(config["sort_mem_percentage"])
+        else:
+            self.sort_mem_percentage = self.SORT_MEM_PERCENTAGE_DEFAULT
 
     def sanity_checks(self):
         """
@@ -104,8 +98,24 @@ class VcfDedupRunner(object):
             message = "Missing parameter 'sort_vcf'"
             logging.error(message)
             raise VcfDedupInputError(message)
+        try:
+            sort_vcf = bool(self.config["sort_vcf"])
+        except ValueError:
+            message = "'sort_vcf' must be boolean and found [%s]" % str(sort_vcf)
+            logging.error(message)
+            raise VcfDedupInputError(message)
         if "sort_threads" not in self.config:
             message = "Missing parameter 'sort_threads'"
+            logging.error(message)
+            raise VcfDedupInputError(message)
+        try:
+            sort_threads = int(self.config["sort_threads"])
+            if sort_threads < 1:
+                message = "'sort_threads' must be positive and greater than zero [%s]" % str(sort_threads)
+                logging.error(message)
+                raise VcfDedupInputError(message)
+        except ValueError:
+            message = "'sort_threads' must be numeric"
             logging.error(message)
             raise VcfDedupInputError(message)
         if "temp_folder" not in self.config:
@@ -134,6 +144,13 @@ class VcfDedupRunner(object):
             logging.error(message)
             raise VcfDedupInputError(message)
         has_valid_sample_idx = "sample_idx" in self.config and self.config["sample_idx"] is not None
+        if has_valid_sample_idx:
+            try:
+                sample_idx = int(self.config["sample_idx"])
+            except ValueError:
+                message = "'sample_idx' must be numeric and found [%s]" % str(sample_idx)
+                logging.error(message)
+                raise VcfDedupInputError(message)
         has_valid_sample_name = "sample_name" in self.config and self.config["sample_name"] is not None
         if self.config["variant_caller"] in [STRELKA_VARIANT_CALLER, STARLING_VARIANT_CALLER] \
                 and not has_valid_sample_idx and not has_valid_sample_name:
@@ -141,12 +158,30 @@ class VcfDedupRunner(object):
                       % self.config["variant_caller"]
             logging.error(message)
             raise VcfDedupInputError(message)
+        if "sort_mem_percentage" in self.config:
+            try:
+                sort_mem_percentage = int(self.config["sort_mem_percentage"])
+                if sort_mem_percentage <= 0 or sort_mem_percentage > 100:
+                    message = "'sort_mem_percentage' must be in the range [1, 100] and it was found [%s]" % \
+                              str(sort_mem_percentage)
+                    logging.error(message)
+                    raise VcfDedupInputError(message)
+            except ValueError:
+                message = "'sort_mem_percentage' must be numeric"
+                logging.error(message)
+                raise VcfDedupInputError(message)
 
     def __sort(self):
         logging.info("Sorts the VCF before processing...")
         input_basename = os.path.splitext(os.path.basename(self.input_vcf))[0]
         self.sorted_vcf = os.path.join(self.temp_folder, "." + input_basename + ".sorted.vcf.gz")
-        vcf_sorter = VcfSorter(self.input_vcf, self.sorted_vcf, temp_folder=self.temp_folder, threads=self.sort_threads)
+        vcf_sorter = VcfSorter(
+            self.input_vcf,
+            self.sorted_vcf,
+            temp_folder=self.temp_folder,
+            threads=self.sort_threads,
+            mem_percentage=self.sort_mem_percentage
+        )
         vcf_sorter.sort()
 
     def run(self):

--- a/vcf_dedup/tools/vcf_sorter.py
+++ b/vcf_dedup/tools/vcf_sorter.py
@@ -7,7 +7,7 @@ class VcfSorter(object):
     GREP = "grep"
     ZGREP = "zgrep"
 
-    def __init__(self, input_vcf_file, output_vcf_file, temp_folder = None, threads = 1):
+    def __init__(self, input_vcf_file, output_vcf_file, temp_folder=None, threads=1, mem_percentage=80):
         """
         Constructtor for the VCF sorter
         :param input_vcf_file:
@@ -28,13 +28,21 @@ class VcfSorter(object):
         else:
             self.is_compressed = False
         self.output_vcf = output_vcf_file
-        self.threads = threads
-        logging.info("Running sort with %s threads" % str(threads))
+        if threads is not None and threads > 0:
+            self.threads = threads
+        else:
+            self.threads = 1
+        logging.info("Running sort with %s threads" % str(self.threads))
         if temp_folder is None or temp_folder == "":
             self.temp_folder = os.path.dirname(os.path.realpath(self.output_vcf))
         else:
             self.temp_folder = temp_folder
-        logging.info("Temporary folder [%s]" % temp_folder)
+        logging.info("Temporary folder [%s]" % self.temp_folder)
+        if mem_percentage is not None and mem_percentage > 0 and mem_percentage <= 100:
+            self.mem_percentage = mem_percentage
+        else:
+            self.mem_percentage = 80
+        logging.info("Memory percentage to be used by sort [%s]" % str(self.mem_percentage))
         logging.info("Initialised!")
 
     def __sort(self):
@@ -42,12 +50,15 @@ class VcfSorter(object):
         Pastes the header, sorts the variants by chromosome, position, reference and alternate and compress them
         :return:
         '''
-        sort_command = "({0} '#' {1} && {0} -v '#' {1} | sort {2} {3} -k1,1V -k2,2n -k4,4V -k5,5V) | bgzip > {4}".format(
+        sort_command = "({0} '#' {1} && {0} -v '#' {1} | sort {2} {3} {4} -k1,1V -k2,2n -k4,4V -k5,5V) | bgzip > {5}"\
+            .format(
             self.ZGREP if self.is_compressed else self.GREP,
             self.input_vcf,
             "--parallel=%s" % str(self.threads) if self.threads > 1 else "",
             "--temporary-directory=%s" % self.temp_folder,
-            self.output_vcf)
+            "--buffer-size=%s%%" % str(self.mem_percentage) if self.mem_percentage is not None else "",
+            self.output_vcf
+        )
         logging.info("Running [%s]" % sort_command)
         os.system(sort_command)
 

--- a/vcf_dedup/tools/vcf_transformer.py
+++ b/vcf_dedup/tools/vcf_transformer.py
@@ -212,6 +212,7 @@ class AbstractVcfDedupper(AbstractVcfTransformer):
             self._select_variants = self._select_mode_arbitrary
         self.sample_idx = sample_idx
         self.sample_name = sample_name
+        self.duplications_count = 0
 
     def _transform_variant(self, variant):
         """
@@ -349,7 +350,7 @@ class AbstractVcfDedupper(AbstractVcfTransformer):
         :param variants:
         :return: the merged variant
         """
-        logging.debug("Merging duplicate variants at %s:%s:%s>%s" % (
+        logging.info("Merging duplicate variants at %s:%s:%s>%s" % (
             variants[0].CHROM,
             int(variants[0].POS),
             variants[0].REF,
@@ -364,6 +365,7 @@ class AbstractVcfDedupper(AbstractVcfTransformer):
             merged_variant = self._select_variants(passed_variants)
         elif len(passed_variants) == 0:
             merged_variant = self._select_variants(variants)
+        self.duplications_count += 1
 
         return merged_variant
 
@@ -400,6 +402,8 @@ class AbstractVcfDedupper(AbstractVcfTransformer):
             self.writer.write_record(self.variants[0])
         # clears it
         self.variants = []
+        logging.info("Found %s positions having duplicated variants" % (str(self.duplications_count)))
+
 
     def _calculate_allele_calls(self, variant):
         """


### PR DESCRIPTION
* Major changes
    - Added parameter `--sort-mem-percentage` to control the amount of available memory used by sort command. This is quite low otherwise, default value now set to 80%.

* Minor changes
    - Added parameter `--log-file` to write logs to a file. If not provided these are still written to the standard error.